### PR TITLE
Control if newer or older units show first in team picker

### DIFF
--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.1.3
+* Fix for main DB script changes
+* New feature to control if newer or older units show first in teambuilder picker.
+
 ### 2.1.2
 * Improve unit name search to search on other names/families
 

--- a/src/app/team-builder/components/team-builder-options/team-builder-options.component.html
+++ b/src/app/team-builder/components/team-builder-options/team-builder-options.component.html
@@ -4,6 +4,11 @@
     <button mat-list-item (click)="triggerOption(option.type)">{{option.text}}</button>
     <mat-divider></mat-divider>
   </ng-container>
+  <div mat-subheader>Picker options</div>
+  <ng-container *ngFor="let option of pickerOptions">
+    <button mat-list-item (click)="triggerOption(option.type)">{{option.text}}</button>
+    <mat-divider></mat-divider>
+  </ng-container>
 </mat-action-list>
 
 <ng-container *ngFor="let team of teams">

--- a/src/app/team-builder/components/team-builder-options/team-builder-options.component.ts
+++ b/src/app/team-builder/components/team-builder-options/team-builder-options.component.ts
@@ -12,7 +12,7 @@ export class ValidUnitPipe implements PipeTransform {
    }
 }
 
-export type OptionType = 'startOver' | 'specialsChange' | 'hideSubs' | 'showAllBuffs';
+export type OptionType = 'startOver' | 'specialsChange' | 'hideSubs' | 'showAllBuffs' | 'oldestFirst';
 export interface OptionEvent {
   type: OptionType;
   data: any;
@@ -42,12 +42,16 @@ export class TeamBuilderOptionsComponent implements OnInit {
   optionClick = new EventEmitter<OptionEvent>();
 
   teamOptions: OptionEntry[];
+  pickerOptions: OptionEntry[];
 
   constructor() {
     this.teamOptions = [
       buildOption('startOver', 'Start over'),
       buildOption('hideSubs', 'Show/Hide subs'),
       buildOption('showAllBuffs', 'Show/Hide all buffs')
+    ];
+    this.pickerOptions = [
+      buildOption('oldestFirst', 'Show old/new units first'),
     ];
   }
 

--- a/src/app/team-builder/components/unit-picker/unit-picker.component.ts
+++ b/src/app/team-builder/components/unit-picker/unit-picker.component.ts
@@ -45,11 +45,14 @@ export class UnitPickerComponent implements OnInit {
   team: UnitDetails[];
   current: UnitDetails;
 
+  @LocalStorage()
+  oldestFirst = false;
+
   constructor(
     private dialogRef: MatDialogRef<UnitPickerComponent, UnitDetails>,
     @Inject(MAT_DIALOG_DATA) data: UnitPickerData
   ) {
-    this.units = data.units;
+    this.units = data.units.sort((a, b) => this.oldestFirst ? a.id - b.id : b.id - a.id);
     this.current = data.current;
     this.filter.page = 0;
     this.filter.excludeIds = data.team && data.team.map(u => u.id);

--- a/src/app/team-builder/pages/team-builder/team-builder.component.ts
+++ b/src/app/team-builder/pages/team-builder/team-builder.component.ts
@@ -32,6 +32,8 @@ export class TeamBuilderComponent implements OnInit {
   hideSubs = false;
   @LocalStorage()
   showAllBuffs = false;
+  @LocalStorage()
+  oldestFirst = false;
 
   @ViewChild('optionsNav')
   optionsNav: MatSidenav;
@@ -235,6 +237,10 @@ export class TeamBuilderComponent implements OnInit {
         const specials = new Set<number>(event.data.specials);
         team.main.filter(u => u != null).forEach(u => u.activeSpecial = specials.has(u.id));
         this.updateBuffs();
+        break;
+      case 'oldestFirst':
+        this.oldestFirst = !this.oldestFirst;
+        this.optionsNav.close();
         break;
     }
   }


### PR DESCRIPTION
By default newer units will show first now. 
If user wants old behaviour, he can change it via a new option.