### PR TITLE
Add missing cases for effects

### DIFF
--- a/src/app/shared/models/rumble.d.ts
+++ b/src/app/shared/models/rumble.d.ts
@@ -42,7 +42,8 @@ export type EffectEnum =
   | "damage"
   | "recharge"
   | "boon"
-  | "penalty";
+  | "penalty"
+  | "cleanse";
 export type AttackEffectType = "atk" | "time" | "cut" | "fixed";
 export type RechargeEffectType =  "Special CT" | "RCV" | "percentage" | "fixed";
 export type Direction = "forward" | "radial" | "sideways";

--- a/src/app/shared/pipes/effect.pipe.ts
+++ b/src/app/shared/pipes/effect.pipe.ts
@@ -147,6 +147,8 @@ export class EffectPipe implements PipeTransform {
         return 'When this unit does a ' + condition.stat + ' (limit ' + condition.count + '), ';
       case 'character':
         return `When ${orListFormatter.format(condition.families)} is on ${condition.team}, `;
+      case 'defeat':
+        return `When ${condition.count} characters on ${condition.team === 'crew' ? 'your crew' : 'the enemy crew'} are defeated, `;
       default:
         return 'UNKNOWN CONDITION ' + JSON.stringify(condition);
     }

--- a/src/app/shared/pipes/effect.pipe.ts
+++ b/src/app/shared/pipes/effect.pipe.ts
@@ -101,6 +101,14 @@ export class EffectPipe implements PipeTransform {
           e += effect.chance + '% chance to ' + this.arrayToString(effect.attributes);
         }
         break;
+      case 'cleanse':
+        if (effect.chance) {
+          e += `${effect.chance}% chance to cleanse`;
+        } else {
+          e += `cleanses`;
+        }
+        e += ` ${this.arrayToString(effect.attributes)} debuffs`;
+        break;
       default:
         e += 'UNKNOWN EFFECT ' + JSON.stringify(effect);
         break;

--- a/src/app/shared/pipes/effect.pipe.ts
+++ b/src/app/shared/pipes/effect.pipe.ts
@@ -73,7 +73,13 @@ export class EffectPipe implements PipeTransform {
         }
         break;
       case 'hinderance':
-        e += effect.chance + '% chance to ' + this.arrayToString(effect.attributes);
+        if (effect.chance) {
+          e += effect.chance + '% chance to ' + this.arrayToString(effect.attributes);
+        } else if (effect.amount) {
+          e += `Removes ${effect.amount}% of ${this.arrayToString(effect.attributes)}`;
+        } else {
+          console.warn('unexpected hinderance effect', effect);
+        }
         break;
       case 'boon':
         e += ('chance' in effect ? effect.chance + '% chance to ' : '') + ('Provoke' === this.arrayToString(effect.attributes) ? 'Provoke enemies' : 'reduce ' + this.arrayToString(effect.attributes));
@@ -149,7 +155,13 @@ export class EffectPipe implements PipeTransform {
         targetStr = 'enemy';
  }
     }
-    return ' to ' + ('count' in target ? target.count + ' ' : '') + targetStr
-       + ('stat' in target ? ' with the ' + target.priority + ' ' + target.stat : '');
+
+    const to = ' to ' + ('count' in target ? target.count + ' ' : '') + targetStr;
+
+    if (target.percentage && target.priority && target.stat) {
+      return `${to} with a ${target.percentage}% or ${target.priority} ${target.stat}`;
+    }
+
+    return to + ('stat' in target ? ' with the ' + target.priority + ' ' + target.stat : '');
   }
 }

--- a/src/app/shared/pipes/effect.pipe.ts
+++ b/src/app/shared/pipes/effect.pipe.ts
@@ -98,7 +98,7 @@ export class EffectPipe implements PipeTransform {
           e += 'Inflicts Lv.' + numberFormatter.format(effect.level) + ' ' + this.arrayToString(effect.attributes) + ' down penalty';
         }
         else {
-          e += effect.chance + '% chance to ' + this.arrayToString(effect.attributes);
+          e += (effect.chance || 100) + '% chance to ' + this.arrayToString(effect.attributes);
         }
         break;
       case 'cleanse':

--- a/src/app/shared/pipes/effect.pipe.ts
+++ b/src/app/shared/pipes/effect.pipe.ts
@@ -133,6 +133,8 @@ export class EffectPipe implements PipeTransform {
         return 'When ' + condition.type + ' count is ' + condition.count + ' or ' + condition.comparator + ', ';
       case 'trigger':
         return 'When this unit does a ' + condition.stat + ' (limit ' + condition.count + '), ';
+      case 'character':
+        return `When ${this.arrayToString(condition.families)} is on ${condition.team}, `;
       default:
         return 'UNKNOWN CONDITION ' + JSON.stringify(condition);
     }


### PR DESCRIPTION
This fixes the text of effects that
- Target specific enemies based on their attribute % or lower/higher (eg INT RR Puddin, target 100% CT or lower enemies, Legend Bonney, targets 2 enemies above 80% CT, etc)
![image](https://user-images.githubusercontent.com/7627975/170841410-ab9621d4-348d-4256-aa8e-6a1db8901c24.png)
- Have conditions on other units being on crew (DEX Cat and Dog, STR Boa sisters, Dorry and Broggy, etc)
![image](https://user-images.githubusercontent.com/7627975/170841346-9daa176c-20c6-40e6-8c80-10ed74ea705b.png)
- Cleanse debuffs (RWB)
![image](https://user-images.githubusercontent.com/7627975/170841331-89ab0785-82dd-4fa2-9084-8b2f1af79a2d.png)
- Activate when units are defeated (QCK LT Luffy, when 1 crewmember is defated)
![image](https://user-images.githubusercontent.com/7627975/170841367-5ca6a173-53c5-4021-ac5d-22b8f959e14c.png)
- Have 100% chance to apply a penalty
![image](https://user-images.githubusercontent.com/7627975/170841955-896014b9-2701-4a3f-9ea7-8e041eaf74cb.png)

For a total of 18 units fixed that either had unknown conditions or undefined % chance.

Now when searching the table across all 480 units for "unknown" or "undefined" there are no finds